### PR TITLE
Whitespace errors

### DIFF
--- a/DnsZone.Tests/DnsZoneFileTests.cs
+++ b/DnsZone.Tests/DnsZoneFileTests.cs
@@ -12,6 +12,12 @@ namespace DnsZone.Tests {
     public class DnsZoneFileTests {
 
         [Test]
+        public async Task ParseWhitespace()
+        {
+            var zone = await DnsZoneFile.LoadFromFileAsync(@"Samples/whitespace.com.zone", "whitespace.com");
+        }
+
+        [Test]
         public async Task Parse2Test() {
             var zone = await DnsZoneFile.LoadFromFileAsync(@"Samples/domain.com.zone", "domain.com");
         }

--- a/DnsZone.Tests/Samples/whitespace.com.zone
+++ b/DnsZone.Tests/Samples/whitespace.com.zone
@@ -1,0 +1,23 @@
+﻿;Example file testing leading whitespace on an otherwise blank line.
+	
+			
+$TTL 2h
+@	IN	SOA	ns.host.net.	ns2.host.net.	(
+			2018042701	; serial
+			2h		; refresh
+			15m		; update retry
+			2w		; expiry
+			2h		; minimum
+		)
+		NS	ns.c4.net.
+		NS	ns2.c4.net.
+		MX	10	mail
+		IN	TXT	"v=spf1 +mx +include:c4.net ?all"
+		A	10.0.0.1
+webmail	IN	CNAME	webmail.c4.net.
+admin	IN	CNAME	webmail.c4.net.
+stats	IN	CNAME	stats.host.net.
+mail	IN	A	10.0.0.1
+*	IN	A	10.0.0.1
+
+

--- a/DnsZone.Tests/Samples/whitespace.com.zone
+++ b/DnsZone.Tests/Samples/whitespace.com.zone
@@ -9,13 +9,13 @@ $TTL 2h
 			2w		; expiry
 			2h		; minimum
 		)
-		NS	ns.c4.net.
-		NS	ns2.c4.net.
+		NS	ns.host.net.
+		NS	ns2.host.net.
 		MX	10	mail
-		IN	TXT	"v=spf1 +mx +include:c4.net ?all"
+		IN	TXT	"v=spf1 +mx +include:host.net ?all"
 		A	10.0.0.1
-webmail	IN	CNAME	webmail.c4.net.
-admin	IN	CNAME	webmail.c4.net.
+webmail	IN	CNAME	webmail.host.net.
+admin	IN	CNAME	webmail.host.net.
 stats	IN	CNAME	stats.host.net.
 mail	IN	A	10.0.0.1
 *	IN	A	10.0.0.1

--- a/DnsZone/DnsZoneFile.cs
+++ b/DnsZone/DnsZoneFile.cs
@@ -165,6 +165,10 @@ namespace DnsZone {
             }
 
             var type = context.ReadResourceRecordType();
+            
+            //An RRT.NULL return  indicates we encountered some kind of 
+            //whitespace instead of the ReadResourceRecordType.
+            if (type == ResourceRecordType.NULL) return;
 
             string domainName;
             try {

--- a/DnsZone/Parser/DnsZoneParseContext.cs
+++ b/DnsZone/Parser/DnsZoneParseContext.cs
@@ -90,6 +90,7 @@ namespace DnsZone.Parser {
 
         public ResourceRecordType ReadResourceRecordType() {
             var token = Tokens.Dequeue();
+            if (token.Type == TokenType.Whitespace || token.Type == TokenType.NewLine) return ResourceRecordType.NULL;
             if (token.Type != TokenType.Literal) throw new TokenException("resource record type expected", token);
             return DnsZoneUtils.ParseResourceRecordType(token.StringValue);
         }


### PR DESCRIPTION
This change keeps the parser from throwing an error on whitespace lines that don't contain a record, but do contain whitespace (such as a line containing only a tab).  BIND handles such files without error, but this library was throwing a Resource Type not found error on such lines.